### PR TITLE
WIP: DF-2416: Reduce Docker image size

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
-go: "1.10"
+go: "1.12.1"
 sudo: required
 services:
   - docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,9 @@ ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt \
 
 WORKDIR /go/src/github.com/rapid7/komand-plugin-sdk-go2
 
-RUN apk add --no-cache make && \
+RUN apk add --no-cache make git && \
     make deps && \
     make build && \
     make check && \
     make test && \
-    apk del make
+    apk del make git

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,5 @@ RUN apk add --no-cache make && \
     make deps && \
     make build && \
     make check && \
-    make test
+    make test && \
+    apk del make

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,9 @@ ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt \
 
 WORKDIR /go/src/github.com/rapid7/komand-plugin-sdk-go2
 
-RUN apk add --no-cache make git && \
+RUN apk add --no-cache make git gcc && \
     make deps && \
     make build && \
     make check && \
     make test && \
-    apk del make git
+    apk del make git gcc

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,9 @@ ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt \
 
 WORKDIR /go/src/github.com/rapid7/komand-plugin-sdk-go2
 
-RUN apk add --no-cache make git gcc && \
+RUN apk add --no-cache make git gcc libc-dev && \
     make deps && \
     make build && \
     make check && \
     make test && \
-    apk del make git gcc
+    apk del make git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.9.7
+FROM golang/1.12.1-alpine3.9
 
 ENV BASE=/go/src/github.com/rapid7/komand-plugin-sdk-go2
 ADD . /go/src/github.com/rapid7/komand-plugin-sdk-go2
 
-ENV SSL_CERT_FILE /etc/ssl/certs/ca-certificates.crt
-ENV SSL_CERT_DIR /etc/ssl/certs
-ENV REQUESTS_CA_BUNDLE  /etc/ssl/certs/ca-certificates.crt
+ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt \
+    SSL_CERT_DIR=/etc/ssl/certs \
+    REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
 
 WORKDIR /go/src/github.com/rapid7/komand-plugin-sdk-go2
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,8 @@ ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt \
 
 WORKDIR /go/src/github.com/rapid7/komand-plugin-sdk-go2
 
-RUN make deps && make build && make check && make test
+RUN apk add --no-cache make && \
+    make deps && \
+    make build && \
+    make check && \
+    make test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang/1.12.1-alpine3.9
+FROM golang:1.12.1-alpine3.9
 
 ENV BASE=/go/src/github.com/rapid7/komand-plugin-sdk-go2
 ADD . /go/src/github.com/rapid7/komand-plugin-sdk-go2


### PR DESCRIPTION
Changes: 
- Alpine-based image (smaller size)
- Go v1.12.1
- Single-line ENV commands to reduce intermediary steps
- Update Travis config to use same Go version